### PR TITLE
Make python run faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This PoW is used in Balsn CTF 2019.
 
 We support various languages to help you solve the obnoxious PoW.
 
-- [X] Python 2
-- [X] Python 3
+- [X] Python 2 (optimized by @RobinJadoul)
+- [X] Python 3 (optimized by @RobinJadoul)
 - [X] NodeJs
 - [X] Browser-based
 - [X] Ruby

--- a/solver/python2.py
+++ b/solver/python2.py
@@ -1,1 +1,19 @@
-python3.py
+#!/usr/bin/env python3
+import hashlib
+import sys
+
+def main():
+    prefix = sys.argv[1]
+    difficulty = int(sys.argv[2])
+    bound = 1 << (64 - difficulty)
+
+    i = 0
+    while True:
+        i += 1
+        s = prefix + str(i)
+        if int(hashlib.sha256(s.encode()).hexdigest()[:16], 16) < bound:
+            print(i)
+            exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/solver/python3.py
+++ b/solver/python3.py
@@ -2,21 +2,18 @@
 import hashlib
 import sys
 
-prefix = sys.argv[1]
-difficulty = int(sys.argv[2])
-zeros = '0' * difficulty
+def main():
+    prefix = sys.argv[1]
+    difficulty = int(sys.argv[2])
+    bound = 1 << (64 - difficulty)
 
-def is_valid(digest):
-    if sys.version_info.major == 2:
-        digest = [ord(i) for i in digest]
-    bits = ''.join(bin(i)[2:].zfill(8) for i in digest)
-    return bits[:difficulty] == zeros
+    i = 0
+    while True:
+        i += 1
+        s = prefix + str(i)
+        if int.from_bytes(hashlib.sha256(s.encode()).digest()[:8], "big") < bound:
+            print(i)
+            exit(0)
 
-
-i = 0
-while True:
-    i += 1
-    s = prefix + str(i)
-    if is_valid(hashlib.sha256(s.encode()).digest()):
-        print(i)
-        exit(0)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This avoids building up an entire string of bits, in favor of just checking that the first 8 bytes (in big endian order) are less than 2^(64 - difficulty).
This of course breaks for difficulty >= 64, but that seems like a rather unlikely choice of PoW difficulty anyway :)