### PR TITLE
Make go run fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We support various languages to help you solve the obnoxious PoW.
 - [X] NodeJs
 - [X] Browser-based
 - [X] Ruby
-- [X] Go (contributed by [Lee Xun](https://github.com/LeeXun))
+- [X] Go (contributed by [Lee Xun](https://github.com/LeeXun), optimized by @RobinJadoul)
 - [ ] Rust
 - [ ] C/C++
 - [ ] Java


### PR DESCRIPTION
This speeds up the validity checking in the go solver, and adds a main function so that it can be used directly.
The speedup comes from avoiding more memory allocations and string building, by replacing the binary string check with a count of the leading zeroes of the first 8 hash bytes as uint64 (big endian).
This breaks for difficulty > 64, but that is out of range for any reasonable PoW either way.